### PR TITLE
numpy and scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
+numpy
+scipy
 opencv
 scikit-image
 imutils
-numpy


### PR DESCRIPTION
numpy and scipy need to be installed before opencv can be installed. issue found on python 3.9